### PR TITLE
Update composer.json to allow for Laravel 6 usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "laravel/framework": "~5.5"
+        "laravel/framework": "~5.5|~6.0.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.2|^7.0",


### PR DESCRIPTION
It looks to me like this is the only change that would be needed for the package to work with 6. 6 is basically the next evolution of 5 and a switch to a new versioning structure. It doesn't appear to be like the shift from 4 to 5.